### PR TITLE
特殊な状況でエラーが起きるバグを修正

### DIFF
--- a/src/multi_channel_bpr/model.py
+++ b/src/multi_channel_bpr/model.py
@@ -93,6 +93,8 @@ class MultiChannelBPR:
                                  self.pos_level_dist,
                                  self.train_inter_pos_dict,
                                  mode=neg_item_sampling_mode)
+                if j is None:
+                    continue
                 user_embed, pos_item_embed, neg_item_embed = \
                     perform_gradient_descent(self.user_reps[u]['embed'],
                                              self.item_reps[i],

--- a/src/multi_channel_bpr/sampling.py
+++ b/src/multi_channel_bpr/sampling.py
@@ -100,7 +100,11 @@ def get_neg_item(user_rep, N, n, u, i, pos_level_dist, train_inter_pos_dict,
     else:
         if mode == 'uniform':
             # sample item uniformly from unobserved channel
-            j = np.random.choice(np.setdiff1d(np.arange(n), user_rep['items']))
+            unknown_items = np.setdiff1d(np.arange(n), user_rep['items'])
+            if unknown_items.size == 0:
+                j = None
+            else:
+                j = np.random.choice(unknown_items)
 
         elif mode == 'non-uniform':
             # sample item non-uniformly from unobserved channel


### PR DESCRIPTION
すべてのモールショップに対してViewがあり、かつどのショップにもClick, Orderがない場合、エラーが起きる。
このようなユーザに対しては学習をスキップすることで対処した。